### PR TITLE
hotfix: ajuste de parametro dentro da funcao de envio para o S3

### DIFF
--- a/utils/upload_s3.py
+++ b/utils/upload_s3.py
@@ -12,7 +12,7 @@ def upload_to_s3(
 ):
     client = boto3.client(
         "s3",
-        aws_region_name=aws_region_name,
+        region_name=aws_region_name,
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
     )


### PR DESCRIPTION
Na função o parâmetro estava incorreto.
Correção aplicada para que o parâmetro de região fosse corretamente passado no momento da conexão com o bucket.